### PR TITLE
feat: make usernames and profile images clickable to route to /profile/:id (#2)

### DIFF
--- a/entwined-server/routes/posts.js
+++ b/entwined-server/routes/posts.js
@@ -251,5 +251,29 @@ router.get("/comments/:postId", auth, async (req, res) => {
   }
 });
 
+/* ===========================
+   GET SINGLE POST
+=========================== */
+
+router.get("/:postId", auth, async (req, res) => {
+  try {
+    const post = await Post.findById(req.params.postId)
+      .populate("user", "username profileImage")
+      .populate({
+        path: "comments",
+        populate: { path: "user", select: "username profileImage" },
+      });
+
+    if (!post) {
+      return res.status(404).json({ error: "Post not found" });
+    }
+
+    return res.json(post);
+  } catch (err) {
+    console.error("Post fetch error:", err);
+    return res.status(500).json({ error: "Failed to fetch post" });
+  }
+});
+
 
 module.exports = router;

--- a/entwined-web/src/components/Chat.jsx
+++ b/entwined-web/src/components/Chat.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import api from "../api/api";
 import { useSocket } from "../contexts/SocketContext";
 import { useAuth } from "../contexts/AuthContext";
@@ -7,6 +7,7 @@ import "../styles/Chat.css";
 import GroupGoals from "../components/group/GroupGoals";
 import ActiveGoalBanner from "../components/group/ActiveGoalBanner";
 export default function Chat() {
+  const navigate = useNavigate();
   const [conversations, setConversations] = useState([]);
   const [friends, setFriends] = useState([]);
   const [selectedConversation, setSelectedConversation] = useState(null);
@@ -379,7 +380,10 @@ export default function Chat() {
     return user?._id;
   };
 
-  const getProfilePath = (userId) => (userId ? `/profile/${userId}` : null);
+  const getProfilePath = (userId) =>
+    (userId ? `/dashboard/profile/${userId}` : null);
+  const getPostPath = (postId) =>
+    (postId ? `/dashboard/post/${postId}` : null);
 
   const isBookClub = selectedConversation?.groupType === "bookclub";
   console.log("Selected Conversation:", selectedConversation);
@@ -553,13 +557,29 @@ export default function Chat() {
                         <div className="message-text">{message.text}</div>
                       )}
                       {message.postId && (
-                        <div className="shared-post-preview">
+                        <div
+                          className="shared-post-preview shared-post-open"
+                          role="button"
+                          tabIndex={0}
+                          onClick={() => {
+                            const target = getPostPath(message.postId._id);
+                            if (target) navigate(target);
+                          }}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
+                              const target = getPostPath(message.postId._id);
+                              if (target) navigate(target);
+                            }
+                          }}
+                        >
                           <div className="shared-post-header">
                             Shared post by @
                             {getProfilePath(message.postId.user?._id) ? (
                               <Link
                                 to={getProfilePath(message.postId.user?._id)}
                                 className="profile-link"
+                                onClick={(event) => event.stopPropagation()}
                               >
                                 {message.postId.user?.username || "Reader"}
                               </Link>

--- a/entwined-web/src/components/Chat.jsx
+++ b/entwined-web/src/components/Chat.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import { Link } from "react-router-dom";
 import api from "../api/api";
 import { useSocket } from "../contexts/SocketContext";
 import { useAuth } from "../contexts/AuthContext";
@@ -378,6 +379,8 @@ export default function Chat() {
     return user?._id;
   };
 
+  const getProfilePath = (userId) => (userId ? `/profile/${userId}` : null);
+
   const isBookClub = selectedConversation?.groupType === "bookclub";
   console.log("Selected Conversation:", selectedConversation);
   return (
@@ -438,7 +441,17 @@ export default function Chat() {
                 className="friend-item"
                 onClick={() => handleFriendClick(friend)}
               >
-                {friend.username}
+                {getProfilePath(friend._id) ? (
+                  <Link
+                    to={getProfilePath(friend._id)}
+                    className="profile-link"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {friend.username}
+                  </Link>
+                ) : (
+                  <span>{friend.username}</span>
+                )}
               </div>
             ))}
           </div>
@@ -543,7 +556,16 @@ export default function Chat() {
                         <div className="shared-post-preview">
                           <div className="shared-post-header">
                             Shared post by @
-                            {message.postId.user?.username || "Reader"}
+                            {getProfilePath(message.postId.user?._id) ? (
+                              <Link
+                                to={getProfilePath(message.postId.user?._id)}
+                                className="profile-link"
+                              >
+                                {message.postId.user?.username || "Reader"}
+                              </Link>
+                            ) : (
+                              <span>{message.postId.user?.username || "Reader"}</span>
+                            )}
                           </div>
                           {message.postId.imageUrl && (
                             <img

--- a/entwined-web/src/components/CommentSection.jsx
+++ b/entwined-web/src/components/CommentSection.jsx
@@ -10,7 +10,7 @@ export default function CommentSection({ comments }) {
       {comments.map((comment) => {
         const username = comment.user?.username || "Reader";
         const profilePath = comment.user?._id
-          ? `/profile/${comment.user._id}`
+          ? `/dashboard/profile/${comment.user._id}`
           : null;
         return (
           <div key={comment._id} className="comment-item">

--- a/entwined-web/src/components/CommentSection.jsx
+++ b/entwined-web/src/components/CommentSection.jsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 export default function CommentSection({ comments }) {
   if (!comments || comments.length === 0) {
     return null;
@@ -7,9 +9,18 @@ export default function CommentSection({ comments }) {
     <div>
       {comments.map((comment) => {
         const username = comment.user?.username || "Reader";
+        const profilePath = comment.user?._id
+          ? `/profile/${comment.user._id}`
+          : null;
         return (
           <div key={comment._id} className="comment-item">
-            <span className="comment-username">@{username}</span>
+            {profilePath ? (
+              <Link to={profilePath} className="comment-username profile-link">
+                @{username}
+              </Link>
+            ) : (
+              <span className="comment-username">@{username}</span>
+            )}
             <span>{comment.text}</span>
           </div>
         );

--- a/entwined-web/src/components/PostCard.jsx
+++ b/entwined-web/src/components/PostCard.jsx
@@ -5,7 +5,7 @@ import CommentSection from "./CommentSection";
 import CommentInput from "./CommentInput";
 import { useAuth } from "../contexts/AuthContext";
 
-export default function PostCard({ post, onUpdated }) {
+export default function PostCard({ post, onUpdated, onOpen }) {
   const [optimisticPost, setOptimisticPost] = useState(post);
   const [liking, setLiking] = useState(false);
   const [showComments, setShowComments] = useState(false);
@@ -94,7 +94,8 @@ export default function PostCard({ post, onUpdated }) {
   const { user, imageUrl, caption } = optimisticPost;
   const username = user?.username || "Reader";
   const profileImage = user?.profileImage;
-  const profilePath = user?._id ? `/profile/${user._id}` : null;
+  const profilePath = user?._id ? `/dashboard/profile/${user._id}` : null;
+  const canOpen = typeof onOpen === "function";
 
   return (
     <article className="post-card">
@@ -125,12 +126,40 @@ export default function PostCard({ post, onUpdated }) {
         )}
       </header>
 
-      <div className="post-image-wrapper">
+      <div
+        className={`post-image-wrapper ${canOpen ? "post-open-target" : ""}`}
+        onClick={() => canOpen && onOpen(optimisticPost)}
+        role={canOpen ? "button" : undefined}
+        tabIndex={canOpen ? 0 : undefined}
+        onKeyDown={(event) => {
+          if (!canOpen) return;
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onOpen(optimisticPost);
+          }
+        }}
+      >
         <img src={imageUrl} alt="Post" />
       </div>
 
       <div className="post-body">
-        {caption && <div className="post-caption">{caption}</div>}
+        {caption && (
+          <div
+            className={`post-caption ${canOpen ? "post-open-target" : ""}`}
+            onClick={() => canOpen && onOpen(optimisticPost)}
+            role={canOpen ? "button" : undefined}
+            tabIndex={canOpen ? 0 : undefined}
+            onKeyDown={(event) => {
+              if (!canOpen) return;
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onOpen(optimisticPost);
+              }
+            }}
+          >
+            {caption}
+          </div>
+        )}
 
         <div className="post-actions">
           <button

--- a/entwined-web/src/components/PostCard.jsx
+++ b/entwined-web/src/components/PostCard.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import api from "../api/api";
 import CommentSection from "./CommentSection";
 import CommentInput from "./CommentInput";
@@ -93,18 +94,35 @@ export default function PostCard({ post, onUpdated }) {
   const { user, imageUrl, caption } = optimisticPost;
   const username = user?.username || "Reader";
   const profileImage = user?.profileImage;
+  const profilePath = user?._id ? `/profile/${user._id}` : null;
 
   return (
     <article className="post-card">
       <header className="post-header">
-        <div className="post-user-avatar">
-          {profileImage ? (
-            <img src={profileImage} alt={`${username} profile`} />
-          ) : (
-            username.charAt(0).toUpperCase()
-          )}
-        </div>
-        <div className="post-username">@{username}</div>
+        {profilePath ? (
+          <Link to={profilePath} className="post-user-avatar profile-link">
+            {profileImage ? (
+              <img src={profileImage} alt={`${username} profile`} />
+            ) : (
+              username.charAt(0).toUpperCase()
+            )}
+          </Link>
+        ) : (
+          <div className="post-user-avatar">
+            {profileImage ? (
+              <img src={profileImage} alt={`${username} profile`} />
+            ) : (
+              username.charAt(0).toUpperCase()
+            )}
+          </div>
+        )}
+        {profilePath ? (
+          <Link to={profilePath} className="post-username profile-link">
+            @{username}
+          </Link>
+        ) : (
+          <div className="post-username">@{username}</div>
+        )}
       </header>
 
       <div className="post-image-wrapper">

--- a/entwined-web/src/components/PostDetailView.jsx
+++ b/entwined-web/src/components/PostDetailView.jsx
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import api from "../api/api";
+import PostCard from "./PostCard";
+
+export default function PostDetailView({ postId }) {
+  const navigate = useNavigate();
+  const [post, setPost] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const fetchPost = useCallback(async () => {
+    if (!postId) {
+      setError("Post not found.");
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const res = await api.get(`/api/posts/${postId}`);
+      setPost(res.data);
+    } catch (err) {
+      console.error("Failed to fetch post", err);
+      setError(err.response?.data?.error || "Unable to load post.");
+    } finally {
+      setLoading(false);
+    }
+  }, [postId]);
+
+  useEffect(() => {
+    fetchPost();
+  }, [fetchPost]);
+
+  return (
+    <div className="single-post-view">
+      <div className="single-post-toolbar">
+        <button type="button" onClick={() => navigate(-1)}>
+          Back
+        </button>
+      </div>
+
+      {loading && <div className="post-card">Loading post...</div>}
+      {!loading && error && <div className="post-card">{error}</div>}
+      {!loading && !error && post && (
+        <PostCard
+          post={post}
+          onUpdated={(updated) => setPost(updated)}
+        />
+      )}
+    </div>
+  );
+}

--- a/entwined-web/src/components/PostFeed.jsx
+++ b/entwined-web/src/components/PostFeed.jsx
@@ -1,9 +1,11 @@
 import { useEffect, useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import api from "../api/api";
 import { useAuth } from "../contexts/AuthContext";
 import PostCard from "./PostCard";
 
 export default function PostFeed() {
+  const navigate = useNavigate();
   const [posts, setPosts] = useState([]);
   const [loading, setLoading] = useState(true);
   const { user } = useAuth();
@@ -66,6 +68,7 @@ export default function PostFeed() {
           <PostCard
             key={post._id}
             post={post}
+            onOpen={(selected) => navigate(`/dashboard/post/${selected._id}`)}
             onUpdated={(updated) => {
               setPosts((prev) =>
                 prev.map((p) => (p._id === updated._id ? updated : p))

--- a/entwined-web/src/components/profile/ProfileDashboard.jsx
+++ b/entwined-web/src/components/profile/ProfileDashboard.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import api from "../../api/api";
 import { useAuth } from "../../contexts/AuthContext";
 import PostCard from "../PostCard";
@@ -21,6 +22,7 @@ const tabs = [
 export default function ProfileDashboard({
   userId: propUserId,
 }) {
+  const navigate = useNavigate();
   const { user, verifyAndFetchUser } = useAuth();
 
   const [activeTab, setActiveTab] = useState("posts");
@@ -437,6 +439,7 @@ export default function ProfileDashboard({
             <PostCard
               key={post._id}
               post={post}
+              onOpen={(selected) => navigate(`/dashboard/post/${selected._id}`)}
               onUpdated={() => loadData()}
             />
           ))}

--- a/entwined-web/src/main.jsx
+++ b/entwined-web/src/main.jsx
@@ -8,10 +8,10 @@ import { SocketProvider } from "./contexts/SocketContext";
 import ProtectedRoute from "./components/ProtectedRoute";
 import Auth from "./pages/Auth";
 import Dashboard from "./pages/Dashboard";
+import ProfilePage from "./pages/ProfilePage";
 import VerifyEmail from "./pages/VerifyEmail";
 import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
-import ProfileDashboard from "./components/profile/ProfileDashboard";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <GoogleOAuthProvider clientId="1029531006959-dpsmtmah0s21u13nt5ncl7mncr09k0v6.apps.googleusercontent.com">
@@ -32,7 +32,14 @@ ReactDOM.createRoot(document.getElementById("root")).render(
           <Route path="/verify-email/:token" element={<VerifyEmail />} />
           <Route path="/forgot-password" element={<ForgotPassword />} />
           <Route path="/reset-password/:token" element={<ResetPassword />} />
-          
+          <Route
+            path="/profile/:id"
+            element={
+              <ProtectedRoute>
+                <ProfilePage />
+              </ProtectedRoute>
+            }
+          />
         </Routes>
       </BrowserRouter>
     </AuthProvider>

--- a/entwined-web/src/pages/Dashboard.jsx
+++ b/entwined-web/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import api from "../api/api";
 import "../styles/Dashboard.css";
 
@@ -194,7 +194,9 @@ export default function Dashboard() {
                 {results.length > 0 ? (
                   results.map((user) => (
                     <div key={user._id} className="user-result">
-                      <span>{user.username}</span>
+                      <Link to={`/profile/${user._id}`} className="profile-link">
+                        {user.username}
+                      </Link>
                       <button onClick={() => sendRequest(user.username)}>Add</button>
                     </div>
                   ))
@@ -208,7 +210,12 @@ export default function Dashboard() {
                 {incoming.length > 0 ? (
                   incoming.map((req) => (
                     <div key={req._id} className="user-result">
-                      <span>{req.sender.username}</span>
+                      <Link
+                        to={`/profile/${req.sender._id}`}
+                        className="profile-link"
+                      >
+                        {req.sender.username}
+                      </Link>
                       <button onClick={() => acceptRequest(req._id)}>Accept</button>
                     </div>
                   ))
@@ -222,17 +229,13 @@ export default function Dashboard() {
               <h2>Friends</h2>
               {friends.length > 0 ? (
                 friends.map((friend) => (
-                  <div
+                  <Link
                     key={friend._id}
-                    className="user-result clickable-user"
-                    onClick={() =>
-                      navigate(
-                        `/dashboard/profile/${friend._id}`
-                      )
-                    }
+                    className="user-result clickable-user profile-link"
+                    to={`/profile/${friend._id}`}
                   >
                     <span>{friend.username}</span>
-                  </div>
+                  </Link>
                 ))
               ) : (
                 <p className="empty-state">Your reading circle is empty.</p>

--- a/entwined-web/src/pages/Dashboard.jsx
+++ b/entwined-web/src/pages/Dashboard.jsx
@@ -6,6 +6,7 @@ import "../styles/Dashboard.css";
 import Chat from "../components/Chat";
 import CreatePost from "../components/CreatePost";
 import PostFeed from "../components/PostFeed";
+import PostDetailView from "../components/PostDetailView";
 import ProfileDashboard from "../components/profile/ProfileDashboard";
 
 export default function Dashboard() {
@@ -15,6 +16,7 @@ export default function Dashboard() {
   location.pathname.split(
     "/dashboard/profile/"
   )[1];
+  const postId = location.pathname.split("/dashboard/post/")[1];
 
   const [activeTab, setActiveTab] = useState(
     location.pathname.includes(
@@ -53,6 +55,9 @@ export default function Dashboard() {
       )
     ) {
       setActiveTab("profile");
+    }
+    if (location.pathname.includes("/dashboard/post/")) {
+      setActiveTab("feed");
     }
   }, [location.pathname]);
   const fetchFriends = useCallback(async () => {
@@ -159,7 +164,13 @@ export default function Dashboard() {
       <main className="dashboard-content">
         {activeTab === "chat" && <Chat />}
 
-        {activeTab === "feed" && (
+        {location.pathname.includes("/dashboard/post/") && (
+          <div className="feed-layout">
+            <PostDetailView postId={postId} />
+          </div>
+        )}
+
+        {activeTab === "feed" && !location.pathname.includes("/dashboard/post/") && (
           <div className="feed-layout">
             <PostFeed />
             <CreatePost />
@@ -194,7 +205,10 @@ export default function Dashboard() {
                 {results.length > 0 ? (
                   results.map((user) => (
                     <div key={user._id} className="user-result">
-                      <Link to={`/profile/${user._id}`} className="profile-link">
+                      <Link
+                        to={`/dashboard/profile/${user._id}`}
+                        className="profile-link"
+                      >
                         {user.username}
                       </Link>
                       <button onClick={() => sendRequest(user.username)}>Add</button>
@@ -211,7 +225,7 @@ export default function Dashboard() {
                   incoming.map((req) => (
                     <div key={req._id} className="user-result">
                       <Link
-                        to={`/profile/${req.sender._id}`}
+                        to={`/dashboard/profile/${req.sender._id}`}
                         className="profile-link"
                       >
                         {req.sender.username}
@@ -232,7 +246,7 @@ export default function Dashboard() {
                   <Link
                     key={friend._id}
                     className="user-result clickable-user profile-link"
-                    to={`/profile/${friend._id}`}
+                    to={`/dashboard/profile/${friend._id}`}
                   >
                     <span>{friend.username}</span>
                   </Link>

--- a/entwined-web/src/pages/ProfilePage.jsx
+++ b/entwined-web/src/pages/ProfilePage.jsx
@@ -1,0 +1,13 @@
+import { useParams } from "react-router-dom";
+import ProfileDashboard from "../components/profile/ProfileDashboard";
+import "../styles/Dashboard.css";
+
+export default function ProfilePage() {
+  const { id } = useParams();
+
+  return (
+    <div className="feed-layout">
+      <ProfileDashboard userId={id} />
+    </div>
+  );
+}

--- a/entwined-web/src/pages/ProfilePage.jsx
+++ b/entwined-web/src/pages/ProfilePage.jsx
@@ -1,13 +1,7 @@
-import { useParams } from "react-router-dom";
-import ProfileDashboard from "../components/profile/ProfileDashboard";
-import "../styles/Dashboard.css";
+import { Navigate, useParams } from "react-router-dom";
 
 export default function ProfilePage() {
   const { id } = useParams();
 
-  return (
-    <div className="feed-layout">
-      <ProfileDashboard userId={id} />
-    </div>
-  );
+  return <Navigate to={`/dashboard/profile/${id}`} replace />;
 }

--- a/entwined-web/src/styles/Chat.css
+++ b/entwined-web/src/styles/Chat.css
@@ -259,6 +259,14 @@
   text-align: left;
 }
 
+.shared-post-open {
+  cursor: pointer;
+}
+
+.shared-post-open:hover {
+  border-color: #cbd5e1;
+}
+
 /* --- File Handling in Messages --- */
 .message-file {
   display: flex;

--- a/entwined-web/src/styles/Chat.css
+++ b/entwined-web/src/styles/Chat.css
@@ -10,6 +10,16 @@
   overflow: hidden; /* Prevents whole-page scrolling */
 }
 
+.profile-link {
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.profile-link:hover {
+  color: #2563eb;
+}
+
 /* --- Left Panel (Sidebar) --- */
 .chat-left-panel {
   width: 350px;

--- a/entwined-web/src/styles/Dashboard.css
+++ b/entwined-web/src/styles/Dashboard.css
@@ -11,6 +11,16 @@
   flex-direction: column;
 }
 
+.profile-link {
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.profile-link:hover {
+  color: #2563eb;
+}
+
 .dashboard-tabs {
   display: flex;
   gap: 0;

--- a/entwined-web/src/styles/Dashboard.css
+++ b/entwined-web/src/styles/Dashboard.css
@@ -136,6 +136,38 @@
   margin-bottom: 8px;
 }
 
+.post-open-target {
+  cursor: pointer;
+}
+
+.post-open-target:hover {
+  opacity: 0.92;
+}
+
+.single-post-view {
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.single-post-toolbar {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.single-post-toolbar button {
+  border: none;
+  background: #ffffff;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 13px;
+  color: #0f172a;
+  cursor: pointer;
+  border: 1px solid #e2e8f0;
+}
+
 .post-actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Description
This PR resolves issue #2 by making usernames and profile images clickable across the platform, improving navigation consistency. 

**Fixes #2**

## Changes Made
* Wrapped user avatars and usernames with the `<Link>` component from `react-router-dom` (or `useNavigate` where appropriate).
* Updated the routing to push the user to `/profile/:id` dynamically based on the associated user's ID.
* Added `cursor: pointer` styling to the clickable elements to ensure proper UX feedback.
* Implemented these changes across the following components:
  * Posts
  * Comments
  * Friend lists
  * Chat sections
  * Shared content cards

## Testing
- [x] Tested locally to ensure routing works correctly without refreshing the page.
- [x] Verified that the correct `:id` is passed to the URL for different users.