### PR TITLE
fix: normalize ObjectId comparisons in chatController (#73)

### DIFF
--- a/entwined-server/controllers/chatController.js
+++ b/entwined-server/controllers/chatController.js
@@ -9,7 +9,7 @@ const getOrCreateConversation = async (req, res) => {
     const { friendId } = req.body;
     const userId = req.userId;
 
-    if (userId === friendId) {
+    if (String(userId) === String(friendId)) {
       return res.status(400).json({ message: "Cannot create conversation with yourself" });
     }
 
@@ -113,7 +113,8 @@ const getMessages = async (req, res) => {
       return res.status(404).json({ message: "Conversation not found" });
     }
 
-    if (!conversation.participants.includes(userId)) {
+    const participantIds = conversation.participants.map(id => id.toString());
+    if (!participantIds.includes(String(userId))) {
       return res.status(403).json({ message: "Not authorized to view this conversation" });
     }
 
@@ -148,7 +149,7 @@ const addGroupMembers = async (req, res) => {
       return res.status(400).json({ message: "Not a group conversation" });
     }
 
-    if (conversation.groupAdmin.toString() !== userId) {
+    if (conversation.groupAdmin.toString() !== String(userId)) {
       return res.status(403).json({ message: "Only group admin can add members" });
     }
 


### PR DESCRIPTION
## Description
This PR resolves an issue where group admins were incorrectly blocked from adding members to a group chat due to strict type comparisons (`!==`) between Mongoose `ObjectId` references and raw strings. 

By normalizing these identifiers using `String()` or `.toString()`, we ensure that equality checks evaluate correctly based on value rather than type mismatch.

## Related Issue
Closes #73

## Changes Made
- **`entwined-server/controllers/chatController.js`**:
  - Updated the authorization guard in `addGroupMembers` to compare string representations of `conversation.groupAdmin` and `userId`.
  - Normalized self-checks in `getOrCreateConversation` using `String()`.
  - Updated the conversation participant validation in `getMessages` to use explicit string conversions during mapping and lookup.

## Verification Checklist
- [x] Static code review completed to ensure no null/undefined property exceptions.
- [x] Verified logic handles strict equality normalization uniformly across the controller.