### PR TITLE
fix: register missing verify and me routes for auth restore (#74)

### DIFF
--- a/entwined-server/routes/authRoutes.js
+++ b/entwined-server/routes/authRoutes.js
@@ -8,7 +8,8 @@ const {
   refreshTokenHandler,
   logout,
   logoutAll,
-  googleLogin
+  googleLogin,
+  verifyToken
 } = require("../controllers/authController");
 const rateLimit = require("express-rate-limit");
 
@@ -34,5 +35,10 @@ router.post("/reset-password/:token", resetPassword);
 router.post("/refresh", refreshTokenHandler);
 router.post("/logout", logout);
 router.post("/logout-all", authMiddleware, logoutAll);
+
+// Validate access token and return current user
+router.get("/verify", authMiddleware, verifyToken);
+// Legacy /me route expected by frontend — reuse verifyToken
+router.get("/me", authMiddleware, verifyToken);
 
 module.exports = router;


### PR DESCRIPTION
## Description
This PR addresses a critical frontend/backend mismatch in the authentication flow. The client-side application expects `/api/auth/verify` (in `AuthContext.jsx`) and `/api/auth/me` (in `Dashboard.jsx`) to validate existing sessions and restore user states on a page refresh. 

Because these endpoints were unmapped on the backend, the server returned `404 Not Found` errors, breaking session persistence and redirecting authenticated users back to the login screen.

## Related Issue
Closes #74

## Changes Made
- **`entwined-server/routes/authRoutes.js`**:
  - Imported the pre-existing `verifyToken` function from `authController`.
  - Registered a `GET /verify` endpoint protected by `authMiddleware` to handle authentication token verification.
  - Registered a `GET /me` endpoint protected by `authMiddleware` to handle active user profile synchronization.

## Verification Checklist
- [x] Confirmed endpoint names perfectly align with frontend network calls (`/api/auth/verify` and `/api/auth/me`).
- [x] Confirmed `authMiddleware` executes prior to the controller to guarantee only valid tokens pull user payloads.