### PR TITLE
fix: redirect on auth refresh failure

### DIFF
--- a/entwined-web/src/api/api.js
+++ b/entwined-web/src/api/api.js
@@ -4,6 +4,31 @@ const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
 });
 
+const PUBLIC_PATHS = ["/", "/forgot-password", "/verify-email", "/reset-password"];
+
+const isPublicPath = (path) =>
+  PUBLIC_PATHS.some((publicPath) =>
+    publicPath === "/" ? path === "/" : path.startsWith(publicPath)
+  );
+
+const clearAuthAndRedirect = () => {
+  localStorage.removeItem("token");
+  localStorage.removeItem("user");
+  window.dispatchEvent(new Event("auth:logout"));
+
+  const { pathname, search, hash } = window.location;
+  if (isPublicPath(pathname)) {
+    return;
+  }
+
+  const returnTo = `${pathname}${search}${hash}`;
+  const loginUrl = `/?redirect=${encodeURIComponent(returnTo)}`;
+
+  if (`${pathname}${search}${hash}` !== loginUrl) {
+    window.location.replace(loginUrl);
+  }
+};
+
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem("token");
   
@@ -52,13 +77,14 @@ api.interceptors.response.use(
     const originalRequest = error.config;
 
     // If 401 and not already retrying
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    if (error.response?.status === 401 && originalRequest && !originalRequest._retry) {
       if (isRefreshing) {
         // If already refreshing, queue this request
         return new Promise((resolve, reject) => {
           failedQueue.push({ resolve, reject });
         })
           .then(token => {
+            originalRequest.headers = originalRequest.headers || {};
             originalRequest.headers.Authorization = `Bearer ${token}`;
             return api(originalRequest);
           })
@@ -88,12 +114,7 @@ api.interceptors.response.use(
       } catch (refreshError) {
         // Refresh failed - clear token and redirect
         processQueue(refreshError, null);
-        localStorage.removeItem("token");
-        
-        const currentPath = window.location.pathname;
-        if (currentPath !== "/" && !currentPath.startsWith("/dashboard")) {
-          window.location.href = "/";
-        }
+        clearAuthAndRedirect();
         
         return Promise.reject(refreshError);
       } finally {

--- a/entwined-web/src/components/ProtectedRoute.jsx
+++ b/entwined-web/src/components/ProtectedRoute.jsx
@@ -1,8 +1,9 @@
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 
 export default function ProtectedRoute({ children }) {
   const { user, loading } = useAuth();
+  const location = useLocation();
 
   // Show loading while AuthContext is verifying token
   if (loading) {
@@ -22,7 +23,8 @@ export default function ProtectedRoute({ children }) {
 
   // If no user after loading, redirect to login
   if (!user) {
-    return <Navigate to="/" replace />;
+    const returnTo = `${location.pathname}${location.search}${location.hash}`;
+    return <Navigate to={`/?redirect=${encodeURIComponent(returnTo)}`} replace />;
   }
 
   return children;

--- a/entwined-web/src/contexts/AuthContext.jsx
+++ b/entwined-web/src/contexts/AuthContext.jsx
@@ -1,5 +1,4 @@
 import { createContext, useContext, useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 import api from "../api/api";
 
 const AuthContext = createContext(null);
@@ -17,12 +16,23 @@ export const AuthProvider = ({ children }) => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    const handleForcedLogout = () => {
+      setUser(null);
+      setLoading(false);
+    };
+
+    window.addEventListener("auth:logout", handleForcedLogout);
+
     const token = localStorage.getItem("token");
     if (token) {
       verifyAndFetchUser();
     } else {
       setLoading(false);
     }
+
+    return () => {
+      window.removeEventListener("auth:logout", handleForcedLogout);
+    };
   }, []);
 
   // Verify token with backend and fetch user data
@@ -52,7 +62,7 @@ export const AuthProvider = ({ children }) => {
             const payload = JSON.parse(atob(token.split(".")[1]));
             setUser({ _id: payload.id });
           }
-        } catch (e) {
+        } catch {
           // Token is malformed, remove it
           localStorage.removeItem("token");
           setUser(null);
@@ -105,6 +115,7 @@ export const AuthProvider = ({ children }) => {
 
   const logout = () => {
     localStorage.removeItem("token");
+    localStorage.removeItem("user");
     setUser(null);
   };
 

--- a/entwined-web/src/pages/Auth.jsx
+++ b/entwined-web/src/pages/Auth.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import axios from "axios";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { GoogleLogin } from "@react-oauth/google";
 import { useAuth } from "../contexts/AuthContext";
 import "../styles/Auth.css";
@@ -19,7 +19,13 @@ export default function Auth() {
   const [resendLoading, setResendLoading] = useState(false);
 
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const API = `${import.meta.env.VITE_API_URL}/api/auth`;
+  const redirectPath = searchParams.get("redirect");
+  const safeRedirectPath =
+    redirectPath && redirectPath.startsWith("/") && !redirectPath.startsWith("//")
+      ? redirectPath
+      : "/dashboard";
 
   /* ================= SIGNUP ================= */
 
@@ -107,7 +113,7 @@ export default function Auth() {
         matches: storedToken === res.data.accessToken
       });
 
-      navigate("/dashboard");
+      navigate(safeRedirectPath);
 
     } catch (err) {
       console.error("❌ [LOGIN] Login error:", err);
@@ -194,7 +200,7 @@ export default function Auth() {
         length: storedToken?.length || 0
       });
 
-      navigate("/dashboard");
+      navigate(safeRedirectPath);
 
     } catch (err) {
       console.error("❌ [GOOGLE LOGIN] Login error:", err);


### PR DESCRIPTION
## Summary
- Standardized refresh-token failure handling in the frontend API interceptor.
- Clears stale auth state when refresh fails.
- Rejects queued requests safely during parallel 401 failures.
- Redirects users away from protected routes with a preserved return path.
- Updates login and Google login to navigate back to the saved protected path after re-authentication.

## Maintainer
This PR is for review by Mannat Berry (@vie-nyx ).

## Related Issue
Closes #57

## Testing
- Ran `npm.cmd run build` successfully.
- `npm.cmd run lint` was attempted, but the repository currently has unrelated pre-existing lint errors in `SocketContext.jsx`, `Dashboard.jsx`, and the existing Fast Refresh export pattern.